### PR TITLE
Remove space-evenly option for layout

### DIFF
--- a/styles/main.scss
+++ b/styles/main.scss
@@ -2543,9 +2543,6 @@ body.presentation {
   &.layout-space-between .line.active > div {
 	  justify-content: space-between;
   }
-  &.layout-space-evenly .line.active > div {
-	  justify-content: space-evenly;
-  }
   &.navigator-height-short iframe {
 	  height: 257px;
   }

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -83,7 +83,6 @@
 		  <li class="mdl-menu__item">Normal</li>
 		  <li class="mdl-menu__item">Space Around</li>
 		  <li class="mdl-menu__item">Space Between</li>
-		  <li class="mdl-menu__item">Space Evenly</li>
 		</ul>
         <span class="mdl-switch__label" id="layout-span"></span>
 		<div class="clear"></div>


### PR DESCRIPTION
This option only worked in Chrome and was the same as normal in Electron